### PR TITLE
Add headers with home link and translate app name

### DIFF
--- a/PrivacyPolicies/PrivacyPolicies.html
+++ b/PrivacyPolicies/PrivacyPolicies.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Privacy Policy - Record Your Love</title>
+    <title>Privacy Policy - 記讀你的愛</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -38,13 +38,40 @@
         a:hover {
             text-decoration: underline;
         }
+        header {
+            background-color: #ff7a59;
+            color: #fff;
+            padding: 20px;
+            text-align: center;
+            position: relative;
+        }
+        header h1 {
+            margin: 0;
+            font-size: 2rem;
+        }
+        header .home-button {
+            position: absolute;
+            right: 20px;
+            top: 50%;
+            transform: translateY(-50%);
+            background-color: #fff;
+            color: #ff7a59;
+            padding: 8px 12px;
+            border-radius: 5px;
+            text-decoration: none;
+            font-size: 0.9rem;
+        }
     </style>
 </head>
 <body>
+    <header>
+        <h1>記讀你的愛</h1>
+        <a class="home-button" href="../index.html">Home</a>
+    </header>
     <div class="container">
         <h1>Privacy Policy</h1>
         <p><strong>Last Updated:</strong> 2025/01/25</p>
-        <p>Your privacy is important to us. This Privacy Policy explains how we collect, use, and protect your personal information when using the <strong>Record Your Love</strong> app.</p>
+        <p>Your privacy is important to us. This Privacy Policy explains how we collect, use, and protect your personal information when using the <strong>記讀你的愛</strong> app.</p>
         
         <h2>1. Information We Collect</h2>
         <ul>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Record Your Love</title>
+    <title>記讀你的愛</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -84,7 +84,7 @@
 </head>
 <body>
     <header>
-        <h1>Record Your Love</h1>
+        <h1>記讀你的愛</h1>
     </header>
 
     <section class="description">

--- a/supports/support.html
+++ b/supports/support.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Record Your Love - Support</title>
+    <title>記讀你的愛 - Support</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -52,18 +52,45 @@
             font-size: 0.9rem;
             color: #999;
         }
+        header {
+            background-color: #ff7a59;
+            color: #fff;
+            padding: 20px;
+            text-align: center;
+            position: relative;
+        }
+        header h1 {
+            margin: 0;
+            font-size: 2rem;
+        }
+        header .home-button {
+            position: absolute;
+            right: 20px;
+            top: 50%;
+            transform: translateY(-50%);
+            background-color: #fff;
+            color: #ff7a59;
+            padding: 8px 12px;
+            border-radius: 5px;
+            text-decoration: none;
+            font-size: 0.9rem;
+        }
     </style>
 </head>
 <body>
+    <header>
+        <h1>記讀你的愛</h1>
+        <a class="home-button" href="../index.html">Home</a>
+    </header>
     <div class="container">
-        <h1>Welcome to Record Your Love Support</h1>
+        <h1>Welcome to 記讀你的愛 Support</h1>
         <p>If you have any questions or need assistance, we're here to help!</p>
 
         <h2>Contact Us</h2>
         <p>Email: <a href="mailto:support@chiuGaStudio.com">support@chiuGaStudio.com</a></p>
 
         <h2>Frequently Asked Questions (FAQ)</h2>
-        <p><strong>Q: How do I use Record Your Love?</strong><br>A: Open the app and follow the on-screen instructions to record your collections.</p>
+        <p><strong>Q: How do I use 記讀你的愛?</strong><br>A: Open the app and follow the on-screen instructions to record your collections.</p>
         <p><strong>Q: How can I report a bug?</strong><br>A: Email us with details at <a href="mailto:support@chiuGaStudio.com">support@chiuGaStudio.com</a>.</p>
     </div>
 


### PR DESCRIPTION
## Summary
- localize the site title and headers to 記讀你的愛
- add a header with a Home link to the support page
- add a header with a Home link to the privacy policy page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688776ce9518832ba9575b169b0d3bb6