### PR TITLE
Update support and privacy pages to zh-Hant

### DIFF
--- a/PrivacyPolicies/PrivacyPolicies.html
+++ b/PrivacyPolicies/PrivacyPolicies.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Privacy Policy - 記讀你的愛</title>
+    <title>隱私權政策 - 記讀你的愛</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -54,8 +54,8 @@
             right: 20px;
             top: 50%;
             transform: translateY(-50%);
-            background-color: #fff;
-            color: #ff7a59;
+            background-color: #ff7a59; /* match header color */
+            color: #fff;
             padding: 8px 12px;
             border-radius: 5px;
             text-decoration: none;
@@ -65,49 +65,49 @@
 </head>
 <body>
     <header>
-        <a class="home-button" href="../index.html">Home</a>
+        <a class="home-button" href="../index.html">首頁</a>
     </header>
     <div class="container">
-        <h1>Privacy Policy</h1>
-        <p><strong>Last Updated:</strong> 2025/01/25</p>
-        <p>Your privacy is important to us. This Privacy Policy explains how we collect, use, and protect your personal information when using the <strong>記讀你的愛</strong> app.</p>
-        
-        <h2>1. Information We Collect</h2>
+        <h1>隱私權政策</h1>
+        <p><strong>更新日期：</strong> 2025/01/25</p>
+        <p>我們十分重視您的隱私。本政策說明在您使用 <strong>記讀你的愛</strong> 時，我們如何收集、使用與保護您的個人資訊。</p>
+
+        <h2>1. 收集的資訊</h2>
         <ul>
-            <li><strong>Barcode Data:</strong> Collected and stored locally on your device for managing your personal collection.</li>
-            <li><strong>User Data:</strong> We do not collect personal information unless explicitly provided by you.</li>
-            <li><strong>App Usage Data:</strong> Anonymous data may be collected to improve app functionality (e.g., crash reports).</li>
-        </ul>
-        
-        <h2>2. How We Use Your Data</h2>
-        <ul>
-            <li>All barcode data is used solely for managing your personal collection.</li>
-            <li>Data is stored locally and never shared with third parties.</li>
+            <li><strong>條碼資料：</strong> 僅儲存在您的裝置中，供您管理收藏。</li>
+            <li><strong>使用者資料：</strong> 除非您自行提供，我們不會收集任何個人資訊。</li>
+            <li><strong>使用情形資料：</strong> 可能會匿名收集錯誤回報等資訊，以改進功能。</li>
         </ul>
 
-        <h2>3. Permissions</h2>
+        <h2>2. 資訊使用方式</h2>
         <ul>
-            <li><strong>Camera Access:</strong> To scan barcodes and QR codes.</li>
-            <li><strong>Storage Access:</strong> To save or retrieve files related to the app.</li>
+            <li>所有條碼資料僅用於管理您的收藏。</li>
+            <li>資料存放於本機，絕不會與第三方分享。</li>
         </ul>
 
-        <h2>4. Security</h2>
-        <p>We ensure that your data is safe and secure, stored locally on your device, and inaccessible to others unless shared by you.</p>
-
-        <h2>5. Your Rights</h2>
+        <h2>3. 權限需求</h2>
         <ul>
-            <li>You can delete all app data by clearing storage or uninstalling the app.</li>
-            <li>If you have questions about your data, contact us for assistance.</li>
+            <li><strong>相機存取：</strong> 用來掃描條碼與 QR Code。</li>
+            <li><strong>儲存空間：</strong> 用來儲存或讀取與應用程式相關的檔案。</li>
         </ul>
 
-        <h2>6. Changes to This Policy</h2>
-        <p>We may update this policy from time to time. The latest version will always be available in the app or on our website.</p>
+        <h2>4. 安全</h2>
+        <p>我們確保您的資料安全地儲存在本機，除非您自行分享，否則他人無法存取。</p>
 
-        <h2>7. Contact Us</h2>
-        <p>If you have any questions about this Privacy Policy, feel free to contact us:</p>
+        <h2>5. 您的權利</h2>
         <ul>
-            <li><strong>Email:</strong> chiugastudio@gmail.com</li>
-            <li><strong>Developer:</strong> ChiuGa Studio</li>
+            <li>您可以隨時清除儲存或移除應用程式以刪除所有資料。</li>
+            <li>若您對資料有疑問，歡迎與我們聯繫。</li>
+        </ul>
+
+        <h2>6. 政策變更</h2>
+        <p>我們可能不定期更新本政策，最新版本會在應用程式或網站上提供。</p>
+
+        <h2>7. 聯絡我們</h2>
+        <p>若您對本隱私權政策有任何疑問，請透過以下方式聯絡：</p>
+        <ul>
+            <li><strong>電子郵件：</strong> chiugastudio@gmail.com</li>
+            <li><strong>開發者：</strong> ChiuGa Studio</li>
         </ul>
     </div>
 </body>

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
         }
         footer .button {
             display: inline-block;
-            background-color: #ff7a59;
+            background-color: #333; /* match footer background */
             color: #fff;
             padding: 10px 20px;
             border-radius: 5px;
@@ -132,7 +132,7 @@
             margin: 0 10px;
         }
         footer .button:hover {
-            background-color: #e8684c;
+            background-color: #555;
         }
         #faq {
             text-align: center;   /* 讓所有文字置中 */

--- a/supports/support.html
+++ b/supports/support.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>記讀你的愛 - Support</title>
+    <title>記讀你的愛 - 支援</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -68,8 +68,8 @@
             right: 20px;
             top: 50%;
             transform: translateY(-50%);
-            background-color: #fff;
-            color: #ff7a59;
+            background-color: #ff7a59; /* match header color */
+            color: #fff;
             padding: 8px 12px;
             border-radius: 5px;
             text-decoration: none;
@@ -79,22 +79,22 @@
 </head>
 <body>
     <header>
-        <a class="home-button" href="../index.html">Home</a>
+        <a class="home-button" href="../index.html">首頁</a>
     </header>
     <div class="container">
-        <h1>Welcome to 記讀你的愛 Support</h1>
-        <p>If you have any questions or need assistance, we're here to help!</p>
+        <h1>歡迎來到記讀你的愛支援頁面</h1>
+        <p>若您有任何疑問或需要協助，請隨時與我們聯繫。</p>
 
-        <h2>Contact Us</h2>
-        <p>Email: <a href="mailto:support@chiuGaStudio.com">support@chiuGaStudio.com</a></p>
+        <h2>聯絡方式</h2>
+        <p>電子郵件：<a href="mailto:support@chiuGaStudio.com">support@chiuGaStudio.com</a></p>
 
-        <h2>Frequently Asked Questions (FAQ)</h2>
-        <p><strong>Q: How do I use 記讀你的愛?</strong><br>A: Open the app and follow the on-screen instructions to record your collections.</p>
-        <p><strong>Q: How can I report a bug?</strong><br>A: Email us with details at <a href="mailto:support@chiuGaStudio.com">support@chiuGaStudio.com</a>.</p>
+        <h2>常見問題</h2>
+        <p><strong>Q：如何使用記讀你的愛？</strong><br>A：開啟 App 後依照畫面指示掃描或輸入條碼即可。</p>
+        <p><strong>Q：如何回報錯誤？</strong><br>A：請將詳細資訊寄至 <a href="mailto:support@chiuGaStudio.com">support@chiuGaStudio.com</a>。</p>
     </div>
 
     <div class="footer">
-        &copy; 2025 ChiuGa Studio. All rights reserved.
+        &copy; 2025 ChiuGa Studio 版權所有
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- translate `support.html` and `PrivacyPolicies.html` to traditional Chinese
- change Home button style on both pages to orange background with white text
- match footer button colors in `index.html` to black background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68880f28b050832b990ce4c1741fda9c