### PR TITLE
Add header buttons and adjust heights

### DIFF
--- a/PrivacyPolicies/PrivacyPolicies.html
+++ b/PrivacyPolicies/PrivacyPolicies.html
@@ -41,7 +41,7 @@
         header {
             background-color: #ff7a59;
             color: #fff;
-            padding: 10px 20px;
+            padding: 20px 20px;
             display: flex;
             align-items: center;
             justify-content: flex-end;

--- a/index.html
+++ b/index.html
@@ -26,36 +26,17 @@
             margin: 0;
             font-size: 1.5rem;
         }
-        header .menu {
-            position: relative;
-        }
-        header .menu summary {
-            list-style: none;
-            cursor: pointer;
-            font-size: 1.5rem;
-            user-select: none;
-        }
-        header .menu ul {
-            list-style: none;
-            margin: 0;
-            padding: 0;
-            background-color: #ff7a59;
-            position: absolute;
-            right: 0;
-            top: 100%;
-            display: none;
-            white-space: nowrap;
-        }
-        header .menu[open] ul {
+        .nav-buttons {
             display: flex;
+            gap: 10px;
         }
-        header .menu li a {
-            display: block;
-            padding: 10px 20px;
+        .nav-buttons a {
             color: #fff;
             text-decoration: none;
+            padding: 8px 12px;
+            border-radius: 5px;
         }
-        header .menu li a:hover {
+        .nav-buttons a:hover {
             background-color: #e8684c;
         }
          section {
@@ -169,9 +150,8 @@
         }
 
         /* Desktop navigation */
-@media (min-width: 768px) {
-            header .menu summary { display: none; }
-            header .menu ul { display: flex !important; position: static; }
+        @media (min-width: 768px) {
+            .nav-buttons a { padding: 8px 16px; }
         }
 
         /* FAQ styles */
@@ -186,14 +166,11 @@
             <img src="images/logo/app_tag_and_track_without_bg.png" alt="App logo" class="logo">
             <h1>記讀你的愛</h1>
         </div>
-        <details class="menu">
-            <summary>&#9776;</summary>
-            <ul>
-                <li><a href="#home">首頁</a></li>
-                <li><a href="#features">功能說明</a></li>
-                <li><a href="#faq">問與答</a></li>
-            </ul>
-        </details>
+        <nav class="nav-buttons">
+            <a href="#home">首頁</a>
+            <a href="#features">功能說明</a>
+            <a href="#faq">問與答</a>
+        </nav>
     </header>
 
     <section class="description">

--- a/supports/support.html
+++ b/supports/support.html
@@ -70,7 +70,7 @@
         header {
             background-color: #ff7a59;
             color: #fff;
-            padding: 10px 20px;
+            padding: 20px 20px;
             display: flex;
             align-items: center;
             justify-content: flex-end;


### PR DESCRIPTION
## Summary
- add dedicated navigation buttons to the home page
- enlarge header heights on the support and privacy policy pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888187bd870832b83e5e169313696c6