### PR TITLE
Add language switcher

### DIFF
--- a/PrivacyPolicies/PrivacyPolicies.html
+++ b/PrivacyPolicies/PrivacyPolicies.html
@@ -91,7 +91,13 @@
 </head>
 <body>
     <header>
-        <a class="home-button" href="../index.html">首頁</a>
+        <a class="home-button" href="../index.html" data-i18n="home_button">首頁</a>
+        <select id="language-switcher">
+            <option value="zh-Hant">繁體中文</option>
+            <option value="en">English</option>
+            <option value="ja">日本語</option>
+            <option value="ko">한국어</option>
+        </select>
     </header>
     <div class="container">
         <h1>隱私權政策</h1>
@@ -139,9 +145,34 @@
     <footer>
         <span>© 2025 記讀你的愛. 版權所有 | 用心設計，來自台灣</span>
         <span>
-            <a class="button" href="../supports/support.html">支援</a>
-            <a class="button" href="PrivacyPolicies.html">隱私權政策</a>
+            <a class="button" href="../supports/support.html" data-i18n="support_button">支援</a>
+            <a class="button" href="PrivacyPolicies.html" data-i18n="privacy_policy_button">隱私權政策</a>
         </span>
     </footer>
+    <script>
+        const pageTranslations = {
+            "zh-Hant": {
+                home_button: "首頁",
+                support_button: "支援",
+                privacy_policy_button: "隱私權政策"
+            },
+            en: {
+                home_button: "Home",
+                support_button: "Support",
+                privacy_policy_button: "Privacy Policy"
+            },
+            ja: {
+                home_button: "ホーム",
+                support_button: "サポート",
+                privacy_policy_button: "プライバシーポリシー"
+            },
+            ko: {
+                home_button: "홈",
+                support_button: "지원",
+                privacy_policy_button: "개인정보 처리방침"
+            }
+        };
+    </script>
+    <script src="../js/language-switcher.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -167,10 +167,16 @@
             <h1>記讀你的愛</h1>
         </div>
         <nav class="nav-buttons">
-            <a href="#home">首頁</a>
-            <a href="#features">功能說明</a>
-            <a href="#faq">問與答</a>
+            <a href="#home" data-i18n="nav_home">首頁</a>
+            <a href="#features" data-i18n="nav_features">功能說明</a>
+            <a href="#faq" data-i18n="nav_faq">問與答</a>
         </nav>
+        <select id="language-switcher">
+            <option value="zh-Hant">繁體中文</option>
+            <option value="en">English</option>
+            <option value="ja">日本語</option>
+            <option value="ko">한국어</option>
+        </select>
     </header>
 
     <section class="description">
@@ -239,9 +245,42 @@
     <footer>
         <span>© 2025 記讀你的愛. 版權所有 | 用心設計，來自台灣</span>
         <span>
-            <a class="button" href="supports/support.html">支援</a>
-            <a class="button" href="PrivacyPolicies/PrivacyPolicies.html">隱私權政策</a>
+            <a class="button" href="supports/support.html" data-i18n="support_button">支援</a>
+            <a class="button" href="PrivacyPolicies/PrivacyPolicies.html" data-i18n="privacy_policy_button">隱私權政策</a>
         </span>
     </footer>
+    <script>
+        const pageTranslations = {
+            "zh-Hant": {
+                nav_home: "首頁",
+                nav_features: "功能說明",
+                nav_faq: "問與答",
+                support_button: "支援",
+                privacy_policy_button: "隱私權政策"
+            },
+            en: {
+                nav_home: "Home",
+                nav_features: "Features",
+                nav_faq: "FAQ",
+                support_button: "Support",
+                privacy_policy_button: "Privacy Policy"
+            },
+            ja: {
+                nav_home: "ホーム",
+                nav_features: "機能説明",
+                nav_faq: "よくある質問",
+                support_button: "サポート",
+                privacy_policy_button: "プライバシーポリシー"
+            },
+            ko: {
+                nav_home: "홈",
+                nav_features: "기능 설명",
+                nav_faq: "자주 묻는 질문",
+                support_button: "지원",
+                privacy_policy_button: "개인정보 처리방침"
+            }
+        };
+    </script>
+    <script src="js/language-switcher.js"></script>
 </body>
 </html>

--- a/js/language-switcher.js
+++ b/js/language-switcher.js
@@ -1,0 +1,25 @@
+(function(){
+    function applyLang(lang){
+        if(!window.pageTranslations) return;
+        var trans = pageTranslations[lang];
+        if(!trans) return;
+        document.querySelectorAll('[data-i18n]').forEach(function(el){
+            var key = el.getAttribute('data-i18n');
+            if(trans[key]) el.textContent = trans[key];
+        });
+        document.documentElement.setAttribute('lang', lang);
+        localStorage.setItem('lang', lang);
+    }
+
+    document.addEventListener('DOMContentLoaded', function(){
+        var selector = document.getElementById('language-switcher');
+        if(!selector) return;
+        var saved = localStorage.getItem('lang') || document.documentElement.lang || 'zh-Hant';
+        if(!pageTranslations[saved]) saved = 'zh-Hant';
+        selector.value = saved;
+        applyLang(saved);
+        selector.addEventListener('change', function(){
+            applyLang(this.value);
+        });
+    });
+})();

--- a/supports/support.html
+++ b/supports/support.html
@@ -103,7 +103,13 @@
 </head>
 <body>
     <header>
-        <a class="home-button" href="../index.html">首頁</a>
+        <a class="home-button" href="../index.html" data-i18n="home_button">首頁</a>
+        <select id="language-switcher">
+            <option value="zh-Hant">繁體中文</option>
+            <option value="en">English</option>
+            <option value="ja">日本語</option>
+            <option value="ko">한국어</option>
+        </select>
     </header>
     <div class="container">
         <h1>支援頁面</h1>
@@ -122,9 +128,34 @@
     <footer>
         <span>© 2025 記讀你的愛. 版權所有 | 用心設計，來自台灣</span>
         <span>
-            <a class="button" href="support.html">支援</a>
-            <a class="button" href="../PrivacyPolicies/PrivacyPolicies.html">隱私權政策</a>
+            <a class="button" href="support.html" data-i18n="support_button">支援</a>
+            <a class="button" href="../PrivacyPolicies/PrivacyPolicies.html" data-i18n="privacy_policy_button">隱私權政策</a>
         </span>
     </footer>
+    <script>
+        const pageTranslations = {
+            "zh-Hant": {
+                home_button: "首頁",
+                support_button: "支援",
+                privacy_policy_button: "隱私權政策"
+            },
+            en: {
+                home_button: "Home",
+                support_button: "Support",
+                privacy_policy_button: "Privacy Policy"
+            },
+            ja: {
+                home_button: "ホーム",
+                support_button: "サポート",
+                privacy_policy_button: "プライバシーポリシー"
+            },
+            ko: {
+                home_button: "홈",
+                support_button: "지원",
+                privacy_policy_button: "개인정보 처리방침"
+            }
+        };
+    </script>
+    <script src="../js/language-switcher.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable language-switcher JS
- integrate the language switcher into the header of each page
- provide translations for header buttons in four languages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68883dca1b2c832ba6f0ddb10a415678