### PR TITLE
Add full multi-language pages

### DIFF
--- a/PrivacyPolicies/PrivacyPolicies.html
+++ b/PrivacyPolicies/PrivacyPolicies.html
@@ -96,50 +96,50 @@
         </select>
     </header>
     <div class="container">
-        <h1>隱私權政策</h1>
+        <h1 data-i18n="privacy_title">隱私權政策</h1>
         <p class="text-sm text-right mb-4">最近更新日期：2025.7.29</p>
-        <p>我們十分重視您的隱私。本政策說明在您使用 <strong>記讀你的愛</strong> 時，我們如何收集、使用與保護您的個人資訊。</p>
+        <p data-i18n="privacy_intro">我們十分重視您的隱私。本政策說明在您使用 <strong>記讀你的愛</strong> 時，我們如何收集、使用與保護您的個人資訊。</p>
 
-        <h2>1. 收集的資訊</h2>
+        <h2 data-i18n="section1_title">1. 收集的資訊</h2>
         <ul>
-            <li><strong>條碼資料：</strong> 僅儲存在您的裝置中，供您管理收藏。</li>
-            <li><strong>使用者資料：</strong> 除非您自行提供，我們不會收集任何個人資訊。</li>
-            <li><strong>使用情形資料：</strong> 可能會匿名收集錯誤回報等資訊，以改進功能。</li>
+            <li data-i18n="section1_item1"><strong>條碼資料：</strong> 僅儲存在您的裝置中，供您管理收藏。</li>
+            <li data-i18n="section1_item2"><strong>使用者資料：</strong> 除非您自行提供，我們不會收集任何個人資訊。</li>
+            <li data-i18n="section1_item3"><strong>使用情形資料：</strong> 可能會匿名收集錯誤回報等資訊，以改進功能。</li>
         </ul>
 
-        <h2>2. 資訊使用方式</h2>
+        <h2 data-i18n="section2_title">2. 資訊使用方式</h2>
         <ul>
-            <li>所有條碼資料僅用於管理您的收藏。</li>
-            <li>資料存放於本機，絕不會與第三方分享。</li>
+            <li data-i18n="section2_item1">所有條碼資料僅用於管理您的收藏。</li>
+            <li data-i18n="section2_item2">資料存放於本機，絕不會與第三方分享。</li>
         </ul>
 
-        <h2>3. 權限需求</h2>
+        <h2 data-i18n="section3_title">3. 權限需求</h2>
         <ul>
-            <li><strong>相機存取：</strong> 用來掃描條碼與 QR Code。</li>
-            <li><strong>儲存空間：</strong> 用來儲存或讀取與應用程式相關的檔案。</li>
+            <li data-i18n="section3_item1"><strong>相機存取：</strong> 用來掃描條碼與 QR Code。</li>
+            <li data-i18n="section3_item2"><strong>儲存空間：</strong> 用來儲存或讀取與應用程式相關的檔案。</li>
         </ul>
 
-        <h2>4. 安全</h2>
-        <p>我們確保您的資料安全地儲存在本機，除非您自行分享，否則他人無法存取。</p>
+        <h2 data-i18n="section4_title">4. 安全</h2>
+        <p data-i18n="section4_text">我們確保您的資料安全地儲存在本機，除非您自行分享，否則他人無法存取。</p>
 
-        <h2>5. 您的權利</h2>
+        <h2 data-i18n="section5_title">5. 您的權利</h2>
         <ul>
-            <li>您可以隨時清除儲存或移除應用程式以刪除所有資料。</li>
-            <li>若您對資料有疑問，歡迎與我們聯繫。</li>
+            <li data-i18n="section5_item1">您可以隨時清除儲存或移除應用程式以刪除所有資料。</li>
+            <li data-i18n="section5_item2">若您對資料有疑問，歡迎與我們聯繫。</li>
         </ul>
 
-        <h2>6. 政策變更</h2>
-        <p>我們可能不定期更新本政策，最新版本會在應用程式或網站上提供。</p>
+        <h2 data-i18n="section6_title">6. 政策變更</h2>
+        <p data-i18n="section6_text">我們可能不定期更新本政策，最新版本會在應用程式或網站上提供。</p>
 
-        <h2>7. 聯絡我們</h2>
-        <p>若您對本隱私權政策有任何疑問，請透過以下方式聯絡：</p>
+        <h2 data-i18n="section7_title">7. 聯絡我們</h2>
+        <p data-i18n="section7_text">若您對本隱私權政策有任何疑問，請透過以下方式聯絡：</p>
         <ul>
-            <li><strong>電子郵件：</strong> chiugastudio@gmail.com</li>
-            <li><strong>開發者：</strong> Chiu Yu Tsung</li>
+            <li data-i18n="section7_item1"><strong>電子郵件：</strong> chiugastudio@gmail.com</li>
+            <li data-i18n="section7_item2"><strong>開發者：</strong> Chiu Yu Tsung</li>
         </ul>
     </div>
     <footer>
-        <span>© 2025 記讀你的愛. 版權所有 | 用心設計，來自台灣</span>
+        <span data-i18n="footer_text">© 2025 記讀你的愛. 版權所有 | 用心設計，來自台灣</span>
         <span>
             <a class="button" href="../supports/support.html" data-i18n="support_button">支援</a>
             <a class="button" href="PrivacyPolicies.html" data-i18n="privacy_policy_button">隱私權政策</a>
@@ -150,22 +150,118 @@
             "zh-Hant": {
                 home_button: "首頁",
                 support_button: "支援",
-                privacy_policy_button: "隱私權政策"
+                privacy_policy_button: "隱私權政策",
+                privacy_title: "隱私權政策",
+                privacy_intro: "我們十分重視您的隱私。本政策說明在您使用 記讀你的愛 時，我們如何收集、使用與保護您的個人資訊。",
+                section1_title: "1. 收集的資訊",
+                section1_item1: "條碼資料： 僅儲存在您的裝置中，供您管理收藏。",
+                section1_item2: "使用者資料： 除非您自行提供，我們不會收集任何個人資訊。",
+                section1_item3: "使用情形資料： 可能會匿名收集錯誤回報等資訊，以改進功能。",
+                section2_title: "2. 資訊使用方式",
+                section2_item1: "所有條碼資料僅用於管理您的收藏。",
+                section2_item2: "資料存放於本機，絕不會與第三方分享。",
+                section3_title: "3. 權限需求",
+                section3_item1: "相機存取： 用來掃描條碼與 QR Code。",
+                section3_item2: "儲存空間： 用來儲存或讀取與應用程式相關的檔案。",
+                section4_title: "4. 安全",
+                section4_text: "我們確保您的資料安全地儲存在本機，除非您自行分享，否則他人無法存取。",
+                section5_title: "5. 您的權利",
+                section5_item1: "您可以隨時清除儲存或移除應用程式以刪除所有資料。",
+                section5_item2: "若您對資料有疑問，歡迎與我們聯繫。",
+                section6_title: "6. 政策變更",
+                section6_text: "我們可能不定期更新本政策，最新版本會在應用程式或網站上提供。",
+                section7_title: "7. 聯絡我們",
+                section7_text: "若您對本隱私權政策有任何疑問，請透過以下方式聯絡：",
+                section7_item1: "電子郵件： chiugastudio@gmail.com",
+                section7_item2: "開發者： Chiu Yu Tsung",
+                footer_text: "© 2025 記讀你的愛. 版權所有 | 用心設計，來自台灣"
             },
             en: {
                 home_button: "Home",
                 support_button: "Support",
-                privacy_policy_button: "Privacy Policy"
+                privacy_policy_button: "Privacy Policy",
+                privacy_title: "Privacy Policy",
+                privacy_intro: "We value your privacy. This policy explains how Record Your Love collects, uses and protects your information.",
+                section1_title: "1. Information Collected",
+                section1_item1: "Barcode data: stored only on your device for managing your collection.",
+                section1_item2: "User data: we do not collect any personal information unless you provide it yourself.",
+                section1_item3: "Usage data: anonymous error reports may be collected to improve features.",
+                section2_title: "2. How We Use Information",
+                section2_item1: "All barcode data is used solely to manage your collection.",
+                section2_item2: "Data is stored locally and never shared with third parties.",
+                section3_title: "3. Permissions",
+                section3_item1: "Camera access: used for scanning barcodes and QR codes.",
+                section3_item2: "Storage: used to save or read files related to the app.",
+                section4_title: "4. Security",
+                section4_text: "We keep your data safe on your device and do not share it unless you choose to.",
+                section5_title: "5. Your Rights",
+                section5_item1: "You can clear storage or remove the app at any time to delete all data.",
+                section5_item2: "Contact us if you have questions about your data.",
+                section6_title: "6. Policy Changes",
+                section6_text: "We may update this policy periodically; the latest version will be available in the app or on the website.",
+                section7_title: "7. Contact Us",
+                section7_text: "If you have any questions about this policy, contact us at:",
+                section7_item1: "Email: chiugastudio@gmail.com",
+                section7_item2: "Developer: Chiu Yu Tsung",
+                footer_text: "© 2025 Record Your Love. All rights reserved | Designed with care in Taiwan"
             },
             ja: {
                 home_button: "ホーム",
                 support_button: "サポート",
-                privacy_policy_button: "プライバシーポリシー"
+                privacy_policy_button: "プライバシーポリシー",
+                privacy_title: "プライバシーポリシー",
+                privacy_intro: "私たちはあなたのプライバシーを大切にします。本ポリシーでは、記読你的愛がどのように情報を収集・利用・保護するか説明します。",
+                section1_title: "1. 収集する情報",
+                section1_item1: "バーコードデータ: 端末にのみ保存され、コレクション管理に使用されます。",
+                section1_item2: "ユーザーデータ: ご自身が提供しない限り、個人情報は収集しません。",
+                section1_item3: "利用状況データ: 機能改善のため匿名のエラーレポートを収集する場合があります。",
+                section2_title: "2. 情報の利用方法",
+                section2_item1: "すべてのバーコードデータはコレクション管理のみに使用されます。",
+                section2_item2: "データは端末に保存され、第三者と共有されません。",
+                section3_title: "3. 権限の要求",
+                section3_item1: "カメラアクセス: バーコードやQRコードの読み取りに使用します。",
+                section3_item2: "ストレージ: アプリ関連のファイルを保存・読み取りするために使用します。",
+                section4_title: "4. セキュリティ",
+                section4_text: "データは端末に安全に保存され、あなたが共有しない限り他者がアクセスすることはありません。",
+                section5_title: "5. あなたの権利",
+                section5_item1: "いつでも保存内容を消去するかアプリを削除してすべてのデータを消すことができます。",
+                section5_item2: "データについて疑問がある場合はお気軽にお問い合わせください。",
+                section6_title: "6. ポリシーの変更",
+                section6_text: "本ポリシーは随時更新されることがあり、最新版はアプリまたはウェブサイトで提供されます。",
+                section7_title: "7. お問い合わせ",
+                section7_text: "本プライバシーポリシーに関するお問い合わせ先:",
+                section7_item1: "メール: chiugastudio@gmail.com",
+                section7_item2: "開発者: Chiu Yu Tsung",
+                footer_text: "© 2025 記読你的愛。すべての権利を保有 | 台湾から心を込めてデザイン"
             },
             ko: {
                 home_button: "홈",
                 support_button: "지원",
-                privacy_policy_button: "개인정보 처리방침"
+                privacy_policy_button: "개인정보 처리방침",
+                privacy_title: "개인정보 처리방침",
+                privacy_intro: "우리는 당신의 프라이버시를 소중히 생각합니다. 이 정책은 '기록 너의 사랑'이 정보를 어떻게 수집, 사용 및 보호하는지 설명합니다.",
+                section1_title: "1. 수집하는 정보",
+                section1_item1: "바코드 데이터: 기기에만 저장되며 컬렉션 관리에 사용됩니다.",
+                section1_item2: "사용자 데이터: 직접 제공하지 않는 한 개인 정보를 수집하지 않습니다.",
+                section1_item3: "사용 현황 데이터: 기능 개선을 위해 익명 오류 보고가 수집될 수 있습니다.",
+                section2_title: "2. 정보 사용 방법",
+                section2_item1: "모든 바코드 데이터는 컬렉션 관리를 위해서만 사용됩니다.",
+                section2_item2: "데이터는 로컬에 저장되며 제3자와 공유되지 않습니다.",
+                section3_title: "3. 권한 요구",
+                section3_item1: "카메라 접근: 바코드와 QR 코드를 스캔하는 데 사용됩니다.",
+                section3_item2: "저장 공간: 앱 관련 파일을 저장하거나 읽기 위해 사용됩니다.",
+                section4_title: "4. 보안",
+                section4_text: "데이터는 기기에 안전하게 저장되며 사용자가 공유하지 않는 한 다른 사람이 접근할 수 없습니다.",
+                section5_title: "5. 귀하의 권리",
+                section5_item1: "언제든 저장 내용을 삭제하거나 앱을 제거하여 모든 데이터를 삭제할 수 있습니다.",
+                section5_item2: "데이터에 대해 궁금하다면 언제든 문의하십시오.",
+                section6_title: "6. 정책 변경",
+                section6_text: "우리는 주기적으로 본 정책을 업데이트할 수 있으며 최신 버전은 앱이나 웹사이트에서 제공됩니다.",
+                section7_title: "7. 연락처",
+                section7_text: "본 개인정보 처리방침에 대한 문의는 다음으로 연락하십시오:",
+                section7_item1: "이메일: chiugastudio@gmail.com",
+                section7_item2: "개발자: Chiu Yu Tsung",
+                footer_text: "© 2025 기록 너의 사랑. 모든 권리 보유 | 대만에서 정성껏 디자인"
             }
         };
     </script>

--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@
     <header id="home">
         <div class="brand">
             <img src="images/logo/app_tag_and_track_without_bg.png" alt="App logo" class="logo">
-            <h1>記讀你的愛</h1>
+            <h1 data-i18n="app_title">記讀你的愛</h1>
         </div>
         <div class="header-right">
             <nav class="nav-buttons">
@@ -188,18 +188,18 @@
 
     <section class="description">
         <div class="text">
-            <h2 class="desc-title">記讀你的愛</h2>
-            <p>這是一個管理你收藏的應用程式。可以透過掃描條碼，讓你快速建立起你的收藏清單，也可分門別的的瀏覽，並提供分享的功能，讓你輕鬆的分享到任何平台上。</p>
+            <h2 class="desc-title" data-i18n="app_title">記讀你的愛</h2>
+            <p data-i18n="desc_text">這是一個管理你收藏的應用程式。可以透過掃描條碼，讓你快速建立起你的收藏清單，也可分門別的的瀏覽，並提供分享的功能，讓你輕鬆的分享到任何平台上。</p>
         </div>
         <img src="images/iPhone/list_view-portrait.png" alt="App logo">
     </section>
 
-    <h2 id="features">功能說明</h2>
+    <h2 id="features" data-i18n="features_title">功能說明</h2>
 
     <section class="features">
         <div class="card">
             <div class="icon">📷</div>
-            <p>條碼掃描－使用相機掃描 EAN8、EAN13、Code128、Code39 和 QR Code</p>
+            <p data-i18n="feature_scan">條碼掃描－使用相機掃描 EAN8、EAN13、Code128、Code39 和 QR Code</p>
         </div>
         <!-- <div class="card">
             <div class="icon">1️⃣</div>
@@ -207,50 +207,50 @@
         </div> -->
         <div class="card">
             <div class="icon">📋</div>
-            <p>條碼列表－檢視所有儲存的條碼，可依號碼、描述或分類搜尋並刪除不需要的項目</p>
+            <p data-i18n="feature_list">條碼列表－檢視所有儲存的條碼，可依號碼、描述或分類搜尋並刪除不需要的項目</p>
         </div>
         <div class="card">
             <div class="icon">⌨️</div>
-            <p>手動輸入－若無法掃描時手動新增條碼</p>
+            <p data-i18n="feature_manual">手動輸入－若無法掃描時手動新增條碼</p>
         </div>
         <div class="card">
             <div class="icon">✏️</div>
-            <p>條碼詳細畫面－可編輯照片、描述、分類、價格等資訊，並分享截圖</p>
+            <p data-i18n="feature_detail">條碼詳細畫面－可編輯照片、描述、分類、價格等資訊，並分享截圖</p>
         </div>
         <div class="card">
             <div class="icon">🔲</div>
-            <p>QR Code 產生－建立包含所有條碼的 QR Code 並分享</p>
+            <p data-i18n="feature_qr">QR Code 產生－建立包含所有條碼的 QR Code 並分享</p>
         </div>
         <div class="card">
             <div class="icon">⚙️</div>
-            <p>設定－查看簡短指南並分享應用程式連結</p>
+            <p data-i18n="feature_settings">設定－查看簡短指南並分享應用程式連結</p>
         </div>
     </section>
 
     <section id="faq">
-        <h2>問與答</h2>
+        <h2 data-i18n="faq_title">問與答</h2>
         <div id="qa-list">
             <div class="qa-item">
-                <p><strong>Q: 記讀你的愛可以記錄哪些條碼？</strong></p>
-                <p>A: 支援 EAN8、EAN13、Code128、Code39 以及 QR Code 等格式。</p>
+                <p data-i18n="faq_q1"><strong>Q: 記讀你的愛可以記錄哪些條碼？</strong></p>
+                <p data-i18n="faq_a1">A: 支援 EAN8、EAN13、Code128、Code39 以及 QR Code 等格式。</p>
             </div>
             <!-- <div class="qa-item">
                 <p><strong>Q: 如何分享我的條碼清單？</strong></p>
                 <p>A: 在設定頁面產生包含所有條碼的 QR Code 後即可分享。</p>
             </div> -->
             <div class="qa-item">
-                <p><strong>Q: 無法掃描時該怎麼辦？</strong></p>
-                <p>A: 使用手動輸入功能即可新增條碼資料。</p>
+                <p data-i18n="faq_q2"><strong>Q: 無法掃描時該怎麼辦？</strong></p>
+                <p data-i18n="faq_a2">A: 使用手動輸入功能即可新增條碼資料。</p>
             </div>
             <div class="qa-item">
-                <p><strong>Q: 我的資料會被上傳到雲端嗎？</strong></p>
-                <p>A: 所有條碼僅儲存在手機端，不會上傳至第三方服務。</p>
+                <p data-i18n="faq_q3"><strong>Q: 我的資料會被上傳到雲端嗎？</strong></p>
+                <p data-i18n="faq_a3">A: 所有條碼僅儲存在手機端，不會上傳至第三方服務。</p>
             </div>
         </div>
     </section>
 
     <footer>
-        <span>© 2025 記讀你的愛. 版權所有 | 用心設計，來自台灣</span>
+        <span data-i18n="footer_text">© 2025 記讀你的愛. 版權所有 | 用心設計，來自台灣</span>
         <span>
             <a class="button" href="supports/support.html" data-i18n="support_button">支援</a>
             <a class="button" href="PrivacyPolicies/PrivacyPolicies.html" data-i18n="privacy_policy_button">隱私權政策</a>
@@ -263,28 +263,96 @@
                 nav_features: "功能說明",
                 nav_faq: "問與答",
                 support_button: "支援",
-                privacy_policy_button: "隱私權政策"
+                privacy_policy_button: "隱私權政策",
+                app_title: "記讀你的愛",
+                desc_text: "這是一個管理你收藏的應用程式。可以透過掃描條碼，讓你快速建立起你的收藏清單，也可分門別的的瀏覽，並提供分享的功能，讓你輕鬆的分享到任何平台上。",
+                features_title: "功能說明",
+                feature_scan: "條碼掃描－使用相機掃描 EAN8、EAN13、Code128、Code39 和 QR Code",
+                feature_list: "條碼列表－檢視所有儲存的條碼，可依號碼、描述或分類搜尋並刪除不需要的項目",
+                feature_manual: "手動輸入－若無法掃描時手動新增條碼",
+                feature_detail: "條碼詳細畫面－可編輯照片、描述、分類、價格等資訊，並分享截圖",
+                feature_qr: "QR Code 產生－建立包含所有條碼的 QR Code 並分享",
+                feature_settings: "設定－查看簡短指南並分享應用程式連結",
+                faq_title: "問與答",
+                faq_q1: "Q: 記讀你的愛可以記錄哪些條碼？",
+                faq_a1: "A: 支援 EAN8、EAN13、Code128、Code39 以及 QR Code 等格式。",
+                faq_q2: "Q: 無法掃描時該怎麼辦？",
+                faq_a2: "A: 使用手動輸入功能即可新增條碼資料。",
+                faq_q3: "Q: 我的資料會被上傳到雲端嗎？",
+                faq_a3: "A: 所有條碼僅儲存在手機端，不會上傳至第三方服務。",
+                footer_text: "© 2025 記讀你的愛. 版權所有 | 用心設計，來自台灣"
             },
             en: {
                 nav_home: "Home",
                 nav_features: "Features",
                 nav_faq: "FAQ",
                 support_button: "Support",
-                privacy_policy_button: "Privacy Policy"
+                privacy_policy_button: "Privacy Policy",
+                app_title: "Record Your Love",
+                desc_text: "This is an app for managing your collections. Scan barcodes to quickly build your list, browse by category and easily share to any platform.",
+                features_title: "Features",
+                feature_scan: "Barcode scanning - Use the camera to scan EAN8, EAN13, Code128, Code39 and QR Codes",
+                feature_list: "Barcode list - View all saved codes, search by number, description or category and delete unwanted items",
+                feature_manual: "Manual entry - Add barcodes manually when scanning isn't possible",
+                feature_detail: "Barcode detail - Edit photo, description, category and price, then share screenshots",
+                feature_qr: "QR Code generation - Create a QR Code containing all barcodes and share",
+                feature_settings: "Settings - View a quick guide and share the app link",
+                faq_title: "FAQ",
+                faq_q1: "Q: Which barcodes can Record Your Love store?",
+                faq_a1: "A: Supports EAN8, EAN13, Code128, Code39 and QR Code formats.",
+                faq_q2: "Q: What if scanning fails?",
+                faq_a2: "A: Use manual entry to add barcode data.",
+                faq_q3: "Q: Will my data be uploaded to the cloud?",
+                faq_a3: "A: All barcodes are stored only on your device and are never uploaded to third-party services.",
+                footer_text: "© 2025 Record Your Love. All rights reserved | Designed with care in Taiwan"
             },
             ja: {
                 nav_home: "ホーム",
                 nav_features: "機能説明",
                 nav_faq: "よくある質問",
                 support_button: "サポート",
-                privacy_policy_button: "プライバシーポリシー"
+                privacy_policy_button: "プライバシーポリシー",
+                app_title: "あなたの愛を記録",
+                desc_text: "これはあなたのコレクションを管理するアプリです。バーコードをスキャンして素早くリストを作成し、カテゴリ別に閲覧でき、どのプラットフォームにも簡単に共有できます。",
+                features_title: "機能説明",
+                feature_scan: "バーコードスキャン - カメラで EAN8、EAN13、Code128、Code39、QR コードを読み取ります",
+                feature_list: "バーコード一覧 - すべての保存したコードを表示し、番号・説明・カテゴリで検索して不要な項目を削除できます",
+                feature_manual: "手動入力 - スキャンできない場合は手動でバーコードを追加",
+                feature_detail: "バーコード詳細 - 写真や説明、カテゴリ、価格などを編集してスクリーンショットを共有",
+                feature_qr: "QRコード生成 - すべてのバーコードを含むQRコードを作成して共有",
+                feature_settings: "設定 - 簡易ガイドを表示し、アプリのリンクを共有",
+                faq_title: "よくある質問",
+                faq_q1: "Q: 記読你的愛ではどのバーコードを保存できますか？",
+                faq_a1: "A: EAN8、EAN13、Code128、Code39、QRコードなどに対応しています。",
+                faq_q2: "Q: スキャンできない場合はどうすればいいですか？",
+                faq_a2: "A: 手動入力機能でバーコードを追加できます。",
+                faq_q3: "Q: データはクラウドにアップロードされますか？",
+                faq_a3: "A: すべてのバーコードは端末にのみ保存され、第三者サービスへアップロードされません。",
+                footer_text: "© 2025 記読你的愛。すべての権利を保有 | 台湾から心を込めてデザイン"
             },
             ko: {
                 nav_home: "홈",
                 nav_features: "기능 설명",
                 nav_faq: "자주 묻는 질문",
                 support_button: "지원",
-                privacy_policy_button: "개인정보 처리방침"
+                privacy_policy_button: "개인정보 처리방침",
+                app_title: "사랑을 기록해요",
+                desc_text: "이것은 당신의 소장품을 관리하는 앱입니다. 바코드를 스캔하여 빠르게 목록을 만들고 분류별로 살펴볼 수 있으며, 어떤 플랫폼으로도 손쉽게 공유할 수 있습니다.",
+                features_title: "기능 설명",
+                feature_scan: "바코드 스캔 - 카메라로 EAN8, EAN13, Code128, Code39 및 QR 코드를 스캔합니다",
+                feature_list: "바코드 목록 - 저장된 모든 코드를 보고, 번호·설명·분류로 검색하여 필요없는 항목을 삭제할 수 있습니다",
+                feature_manual: "수동 입력 - 스캔할 수 없을 때 수동으로 바코드를 추가",
+                feature_detail: "바코드 상세 화면 - 사진, 설명, 분류, 가격 등을 편집하고 스크린샷을 공유",
+                feature_qr: "QR 코드 생성 - 모든 바코드를 포함한 QR 코드를 만들어 공유",
+                feature_settings: "설정 - 간단한 가이드를 보고 앱 링크를 공유",
+                faq_title: "자주 묻는 질문",
+                faq_q1: "Q: 어떤 바코드를 기록할 수 있나요?",
+                faq_a1: "A: EAN8, EAN13, Code128, Code39 및 QR 코드 형식을 지원합니다.",
+                faq_q2: "Q: 스캔이 안 되면 어떻게 하나요?",
+                faq_a2: "A: 수동 입력 기능으로 바코드 데이터를 추가합니다.",
+                faq_q3: "Q: 데이터가 클라우드에 올라가나요?",
+                faq_a3: "A: 모든 바코드는 기기에만 저장되며 제3자 서비스에 업로드되지 않습니다.",
+                footer_text: "© 2025 기록 너의 사랑. 모든 권리 보유 | 대만에서 정성껏 디자인"
             }
         };
     </script>

--- a/supports/support.html
+++ b/supports/support.html
@@ -108,21 +108,21 @@
         </select>
     </header>
     <div class="container">
-        <h1>支援頁面</h1>
+        <h1 data-i18n="support_title">支援頁面</h1>
         <p class="text-sm text-right mb-4">最近更新日期：2025.7.29</p>
-        <p>歡迎來到 - 記讀你的愛</h1>
-        <p>若您有任何疑問或需要協助，請隨時與我們聯繫。</p>
+        <p data-i18n="support_welcome">歡迎來到 - 記讀你的愛</p>
+        <p data-i18n="support_contact">若您有任何疑問或需要協助，請隨時與我們聯繫。</p>
 
-        <h2>聯絡方式</h2>
-        <p>電子郵件：<a href="mailto:chiugastudio@gmail.com">chiugastudio@gmail.com</a></p>
+        <h2 data-i18n="contact_title">聯絡方式</h2>
+        <p data-i18n="contact_email">電子郵件：<a href="mailto:chiugastudio@gmail.com">chiugastudio@gmail.com</a></p>
 
-        <h2>常見問題</h2>
-        <p><strong>Q：如何使用記讀你的愛？</strong><br>A：開啟 App 後依照畫面指示掃描或輸入條碼即可。</p>
-        <p><strong>Q：如何回報錯誤？</strong><br>A：請將詳細資訊寄至 <a href="mailto:chiugastudio@gmail.com">chiugastudio@gmail.com</a>。</p>
+        <h2 data-i18n="support_faq_title">常見問題</h2>
+        <p data-i18n="support_q1"><strong>Q：如何使用記讀你的愛？</strong><br>A：開啟 App 後依照畫面指示掃描或輸入條碼即可。</p>
+        <p data-i18n="support_q2"><strong>Q：如何回報錯誤？</strong><br>A：請將詳細資訊寄至 <a href="mailto:chiugastudio@gmail.com">chiugastudio@gmail.com</a>。</p>
     </div>
 
     <footer>
-        <span>© 2025 記讀你的愛. 版權所有 | 用心設計，來自台灣</span>
+        <span data-i18n="footer_text">© 2025 記讀你的愛. 版權所有 | 用心設計，來自台灣</span>
         <span>
             <a class="button" href="support.html" data-i18n="support_button">支援</a>
             <a class="button" href="../PrivacyPolicies/PrivacyPolicies.html" data-i18n="privacy_policy_button">隱私權政策</a>
@@ -133,22 +133,58 @@
             "zh-Hant": {
                 home_button: "首頁",
                 support_button: "支援",
-                privacy_policy_button: "隱私權政策"
+                privacy_policy_button: "隱私權政策",
+                support_title: "支援頁面",
+                support_welcome: "歡迎來到 - 記讀你的愛",
+                support_contact: "若您有任何疑問或需要協助，請隨時與我們聯繫。",
+                contact_title: "聯絡方式",
+                contact_email: "電子郵件：chiugastudio@gmail.com",
+                support_faq_title: "常見問題",
+                support_q1: "Q：如何使用記讀你的愛？\nA：開啟 App 後依照畫面指示掃描或輸入條碼即可。",
+                support_q2: "Q：如何回報錯誤？\nA：請將詳細資訊寄至 chiugastudio@gmail.com。",
+                footer_text: "© 2025 記讀你的愛. 版權所有 | 用心設計，來自台灣"
             },
             en: {
                 home_button: "Home",
                 support_button: "Support",
-                privacy_policy_button: "Privacy Policy"
+                privacy_policy_button: "Privacy Policy",
+                support_title: "Support",
+                support_welcome: "Welcome to Record Your Love",
+                support_contact: "If you have any questions or need help, please contact us.",
+                contact_title: "Contact",
+                contact_email: "Email: chiugastudio@gmail.com",
+                support_faq_title: "FAQ",
+                support_q1: "Q: How do I use Record Your Love?\nA: Open the app and follow the instructions to scan or enter barcodes.",
+                support_q2: "Q: How do I report a bug?\nA: Send the details to chiugastudio@gmail.com.",
+                footer_text: "© 2025 Record Your Love. All rights reserved | Designed with care in Taiwan"
             },
             ja: {
                 home_button: "ホーム",
                 support_button: "サポート",
-                privacy_policy_button: "プライバシーポリシー"
+                privacy_policy_button: "プライバシーポリシー",
+                support_title: "サポートページ",
+                support_welcome: "ようこそ - 記読你的愛",
+                support_contact: "ご質問やサポートが必要な場合はお気軽にご連絡ください。",
+                contact_title: "連絡先",
+                contact_email: "メール: chiugastudio@gmail.com",
+                support_faq_title: "よくある質問",
+                support_q1: "Q：記読你的愛はどう使いますか？\nA：アプリを開いて画面の指示に従いバーコードを読み取るか入力してください。",
+                support_q2: "Q：不具合の報告方法は？\nA：詳細を chiugastudio@gmail.com までお送りください。",
+                footer_text: "© 2025 記読你的愛。すべての権利を保有 | 台湾から心を込めてデザイン"
             },
             ko: {
                 home_button: "홈",
                 support_button: "지원",
-                privacy_policy_button: "개인정보 처리방침"
+                privacy_policy_button: "개인정보 처리방침",
+                support_title: "지원 페이지",
+                support_welcome: "기록 너의 사랑에 오신 것을 환영합니다",
+                support_contact: "궁금한 점이나 도움이 필요하면 언제든지 연락 주세요.",
+                contact_title: "연락처",
+                contact_email: "이메일: chiugastudio@gmail.com",
+                support_faq_title: "자주 묻는 질문",
+                support_q1: "Q: Record Your Love은 어떻게 사용하나요?\nA: 앱을 열어 안내에 따라 바코드를 스캔하거나 입력하세요.",
+                support_q2: "Q: 버그는 어떻게 신고하나요?\nA: 세부 정보를 chiugastudio@gmail.com 으로 보내주세요.",
+                footer_text: "© 2025 기록 너의 사랑. 모든 권리 보유 | 대만에서 정성껏 디자인"
             }
         };
     </script>


### PR DESCRIPTION
## Summary
- translate all pages to Chinese, English, Japanese and Korean
- update language switcher text on index, support and privacy policy pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688843891e94832bb4a5e621dd0b7a67