### PR TITLE
Fix mobile layout and add language switcher

### DIFF
--- a/PrivacyPolicies/PrivacyPolicies.html
+++ b/PrivacyPolicies/PrivacyPolicies.html
@@ -62,10 +62,10 @@
         header .home-button:hover {
             background-color: #e8684c;
         }
-                #language-switcher {
-            background-color: #ff7a59;
-            color: #fff;
-            border: none;
+                .language-switcher {
+                    background-color: #ff7a59;
+                    color: #fff;
+                    border: none;
             padding: 8px 12px;
             border-radius: 5px;
         }
@@ -110,7 +110,7 @@
 <body>
     <header>
         <a class="home-button" href="../index.html" data-i18n="home_button">首頁</a>
-        <select id="language-switcher">
+        <select id="language-switcher" class="language-switcher">
             <option value="zh-Hant">繁體中文</option>
             <option value="en">English</option>
             <option value="ja">日本語</option>

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
         .nav-buttons a:hover {
             background-color: #e8684c;
         }
-        #language-switcher {
+        .language-switcher {
             background-color: #ff7a59;
             color: #fff;
             border: none;
@@ -220,13 +220,11 @@
         /* Mobile adjustments */
         @media (max-width: 600px) {
             header {
-                flex-direction: column;
-                align-items: flex-start;
+                flex-direction: row;
+                align-items: center;
             }
             .header-right {
-                width: 100%;
                 justify-content: flex-end;
-                margin-top: 10px;
             }
             .nav-buttons,
             #language-switcher {
@@ -268,7 +266,7 @@
                 <a href="#features" data-i18n="nav_features">功能說明</a>
                 <a href="#faq" data-i18n="nav_faq">問與答</a>
             </nav>
-            <select id="language-switcher">
+            <select id="language-switcher" class="language-switcher">
                 <option value="zh-Hant">繁體中文</option>
                 <option value="en">English</option>
                 <option value="ja">日本語</option>
@@ -278,6 +276,14 @@
                 <li><a href="#home" data-i18n="nav_home">首頁</a></li>
                 <li><a href="#features" data-i18n="nav_features">功能說明</a></li>
                 <li><a href="#faq" data-i18n="nav_faq">問與答</a></li>
+                <li>
+                    <select id="language-switcher-mobile" class="language-switcher">
+                        <option value="zh-Hant">繁體中文</option>
+                        <option value="en">English</option>
+                        <option value="ja">日本語</option>
+                        <option value="ko">한국어</option>
+                    </select>
+                </li>
             </ul>
         </div>
     </header>

--- a/js/language-switcher.js
+++ b/js/language-switcher.js
@@ -12,14 +12,18 @@
     }
 
     document.addEventListener('DOMContentLoaded', function(){
-        var selector = document.getElementById('language-switcher');
-        if(!selector) return;
+        var selectors = document.querySelectorAll('.language-switcher');
+        if(!selectors.length) return;
         var saved = localStorage.getItem('lang') || document.documentElement.lang || 'zh-Hant';
         if(!pageTranslations[saved]) saved = 'zh-Hant';
-        selector.value = saved;
+        selectors.forEach(function(sel){ sel.value = saved; });
         applyLang(saved);
-        selector.addEventListener('change', function(){
-            applyLang(this.value);
+        selectors.forEach(function(sel){
+            sel.addEventListener('change', function(){
+                var value = this.value;
+                selectors.forEach(function(other){ other.value = value; });
+                applyLang(value);
+            });
         });
     });
 })();

--- a/supports/support.html
+++ b/supports/support.html
@@ -98,7 +98,7 @@
         header .home-button:hover {
             background-color: #e8684c;
         }
-         #language-switcher {
+         .language-switcher {
             background-color: #ff7a59;
             color: #fff;
             border: none;
@@ -122,7 +122,7 @@
 <body>
     <header>
         <a class="home-button" href="../index.html" data-i18n="home_button">首頁</a>
-        <select id="language-switcher">
+        <select id="language-switcher" class="language-switcher">
             <option value="zh-Hant">繁體中文</option>
             <option value="en">English</option>
             <option value="ja">日本語</option>


### PR DESCRIPTION
## Summary
- keep header layout horizontal on small screens
- show language switcher inside the mobile menu
- allow multiple language switchers in JS
- update pages to use new language-switcher class

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_688b2a5552c4832b9e1d821310c0fc96